### PR TITLE
Undefined variable: fullText

### DIFF
--- a/RecentPages.php
+++ b/RecentPages.php
@@ -461,6 +461,7 @@ class RecentPages {
                     $title = $retArray[ $i - 1 ];
                     if ( !is_null( $title ) ) {
                         $html = RecentPages::getDisplayTitle ( $title, $args, $displayTitles );
+                        $fullText = RecentPages::getFullText( $title );
                         $ret .= $bulletChar . $parser->internalParse ( '[[' . RecentPages::getFullText ( $title )
                             . '|' . $html . ']]' ) . $endChar
                             . $parser->internalParse( str_replace ( '$1', $fullText, $parsedEndChar ) );
@@ -471,6 +472,7 @@ class RecentPages {
                     $title = $retArray[ $i ];
                     if ( !is_null( $title ) ) {
                         $html = RecentPages::getDisplayTitle ( $title, $args, $displayTitles );
+                        $fullText = RecentPages::getFullText( $title );
                         $ret .= $bulletChar . $parser->internalParse ( '[[' . RecentPages::getFullText ( $title )
                             . '|' . $html . ']]' ) . $endChar
                             . $parser->internalParse( str_replace ( '$1', $fullText, $parsedEndChar ) );


### PR DESCRIPTION
For each page view I got the following messages multiple times in my error.log: 

```
PHP message: PHP Notice:  Undefined variable: fullText in ../extensions/RecentPages/RecentPages.php on line 476
```

This patch defines ```$fullText``` and makes the message go away.