### PR TITLE
Remove $wgUser->getSkin(); to prevent Fatal Error

### DIFF
--- a/RecentPages.php
+++ b/RecentPages.php
@@ -76,8 +76,6 @@ class RecentPages {
         # Prevent caching
         $parser->disableCache();
 
-        $skin = $wgUser->getSkin();
-
         $ret = "";
 
         $sort = $wgRecentPagesDefaultSort;


### PR DESCRIPTION
The code

``` php
$skin = $wgUser->getSkin();
```

return the error "Fatal error: Call to undefined method User::getSkin()" in modern MW versions.
`User::getSkin` was deprecated in MediaWiki 1.18, and this code appears to do nothing useful in the extension, so I propose to remove it.
See also https://www.mediawiki.org/wiki/Topic:Stk66j7xzrfc9n8i
